### PR TITLE
Sync optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ Known Issue: Chromecasts cannot follow, but can lead.  Workaround by controlling
 # Development
 API reference:
 [http://swagger.emby.media/?staticview=true#/SessionsService/](http://swagger.emby.media/?staticview=true#/SessionsService/)
+
+## Start Development Server
+```
+python dev_start.py
+```
+For the dev server, the host and port can be defined by using environment variables:  
+```
+export HOST="0.0.0.0"
+export PORT="5000"
+python dev_start.py
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # emby-sync
 
+Running the server in docker:
 
 `docker run --name emby-sync -e EMBY_SERVER='<emby_url>' -e SECRET_KEY='<emby_api_key>' -p 5000:5000 lastelement21/emby-sync:latest`
 
@@ -14,6 +15,9 @@ SECRET_KEY: This should be an API key for your emby server.
 EMBY_SERVER: This should be the URL used to connect to your server.
 
 (Optional) DEFAULT_ROOM: A room name which always exists. Default is 'Bacon Bar'
+
+(Optional) INTERVAL: The interval of the synchronization loop, in seconds. Default '3.0' seconds.
+Setting this shorter will yield a higher load on the Emby server, but on a low latency connection can give very good synchronization results.
 
 Known Issue: Chromecasts cannot follow, but can lead.  Workaround by controlling the device casting to the Chromecast.
 

--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ EMBY_SERVER: This should be the URL used to connect to your server.
 (Optional) DEFAULT_ROOM: A room name which always exists. Default is 'Bacon Bar'
 
 Known Issue: Chromecasts cannot follow, but can lead.  Workaround by controlling the device casting to the Chromecast.
+
+# Development
+API reference:
+[http://swagger.emby.media/?staticview=true#/SessionsService/](http://swagger.emby.media/?staticview=true#/SessionsService/)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,7 @@ login.login_view = 'login'
 bootstrap = Bootstrap(app)
 
 from app.functions import *
-app.apscheduler.add_job(func=sync_cycle, trigger='interval', seconds=3, id='sync_cycle')
+INTERVAL = float(Config.INTERVAL)
+app.apscheduler.add_job(func=sync_cycle, trigger='interval', seconds=INTERVAL, id='sync_cycle')
 
 from app import routes, models, functions

--- a/app/functions.py
+++ b/app/functions.py
@@ -213,7 +213,7 @@ def comparetoleader(leader_session : Session, follower_session : Session, follow
 
     elif (leader_session.playing == True) and (follower_session.playing == True)\
             and (leader_session.item_id == follower_session.item_id)\
-            and (leader_session.is_paused == True and leader_session.is_paused == False):
+            and (leader_session.is_paused == True and follower_session.is_paused == False):
         # Leader is playing but paused. Follower is playing
         # and not yet paused
         # Pause the follower and seek it to the leader

--- a/app/routes.py
+++ b/app/routes.py
@@ -63,10 +63,10 @@ def login():
         return redirect(url_for('index'))
     form = LoginForm()
     if form.validate_on_submit():
-        if not check_password(form.username.data, form.password.data):
+        authenticated, user = check_password(form.username.data, form.password.data)
+        if not authenticated:
             flash('Invalid username or password')
             return redirect(url_for('login'))
-        user = User.query.filter_by(username=form.username.data.lower()).first()
         login_user(user, remember=form.remember_me.data)
         next_page = request.args.get('next')
         if not next_page or url_parse(next_page).netloc != '':

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ class Config(object):
     SECRET_KEY = os.environ.get('SECRET_KEY')
     EMBY_SERVER = os.environ.get('EMBY_SERVER')
     DEFAULT_ROOM = os.environ.get('DEFAULT_ROOM') or 'Bacon Bar'
-    INTERVAL = os.getenv("INTERVAL", "0.5")
+    INTERVAL = os.getenv("INTERVAL", "3.0")
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ class Config(object):
     SECRET_KEY = os.environ.get('SECRET_KEY')
     EMBY_SERVER = os.environ.get('EMBY_SERVER')
     DEFAULT_ROOM = os.environ.get('DEFAULT_ROOM') or 'Bacon Bar'
-    INTERVAL = os.getenv("INTERVAL", "3.0")
+    INTERVAL = os.getenv("INTERVAL", "0.5")
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ class Config(object):
     SECRET_KEY = os.environ.get('SECRET_KEY')
     EMBY_SERVER = os.environ.get('EMBY_SERVER')
     DEFAULT_ROOM = os.environ.get('DEFAULT_ROOM') or 'Bacon Bar'
+    INTERVAL = os.getenv("INTERVAL", "3.0")
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/dev_start.py
+++ b/dev_start.py
@@ -1,0 +1,7 @@
+import os
+
+from app import app
+if __name__ == "__main__":
+    host = os.getenv("HOST", "127.0.0.1")
+    port = os.getenv("PORT", 5000)
+    app.run(host="0.0.0.0", port=port, debug=True)


### PR DESCRIPTION
The main changes in this PR:
- Refactoring the main loop to split out the comparison of the follower to the leader
- Added Seek versus normal Play for syncing
-  Added INTERVAL environment variable

In detail:
If the follower already plays the same item as the leader, seeking is more efficient than using the normal play instruction.
Furthermore, when the leader pauses, that is a good moment for all clients to seek to the same spot, regardless of current drift status. As the players should all pause, buffering and such shouldn't be an issue.   
If the emby-sync server has a low latency connection to the emby server, having all followers within 1 second is easily achievable.

This means that the normal 'set_playtime' now uses seeking, and 'start_play' sets the follower to play the same item, at the starting point of the leader.  

Login now does one less database query and uses typed functions. I found that if the Emby Connect username wasn't the same as the normal username, the database could become inconsistent.

Added INTERVAL environment variable which lets you set how fast the app needs to cycle. Lower means better synchronization, but higher cpu usage. And if the sync cycle is below your ping to the emby server it is possible that requests start to interleave.

Added a small dev server implementation with debug flag for easier debugging, with instructions in the README.

Tested with:
Edge as leader + Edge as follower
Firefox as leader + Edge as follower
Edge as leader + Firefox as follower
Chrome as Leader + Firefox as follower
